### PR TITLE
WP 7.0 compatibility — v1.14.2

### DIFF
--- a/cardcrafter.php
+++ b/cardcrafter.php
@@ -3,7 +3,7 @@
  * Plugin Name: CardCrafter – Data-Driven Card Grids
  * Plugin URI: https://github.com/TableCrafter/cardcrafter-data-grids
  * Description: Transform JSON data and WordPress posts into beautiful card grids. Perfect for teams, products, portfolios, and blogs.
- * Version: 1.14.1
+ * Version: 1.14.2
  * Author: fahdi
  * Author URI: https://github.com/TableCrafter
  * License: GPLv2 or later
@@ -20,7 +20,7 @@ Note: Plugin name and slug updated to CardCrafter – Data-Driven Card Grids / c
 All functional code remains unchanged. These changes are recommended by an AI and do not replace WordPress.org volunteer review guidance.
 */
 
-define('CARDCRAFTER_VERSION', '1.14.1');
+define('CARDCRAFTER_VERSION', '1.14.2');
 define('CARDCRAFTER_URL', plugin_dir_url(__FILE__));
 define('CARDCRAFTER_PATH', plugin_dir_path(__FILE__));
 

--- a/elementor/class-cardcrafter-elementor-widget.php
+++ b/elementor/class-cardcrafter-elementor-widget.php
@@ -343,7 +343,8 @@ class CardCrafter_Elementor_Widget extends Widget_Base
             [
                 'type' => Controls_Manager::RAW_HTML,
                 'raw' => sprintf(
-                    __('%sElementor Pro Required%s This feature requires Elementor Pro to use dynamic tags and field plugins like ACF, Meta Box, Toolset, etc.', 'cardcrafter-data-grids'),
+                    /* translators: 1: opening <strong> tag, 2: closing </strong> tag followed by <br> */
+                    __('%1$sElementor Pro Required%2$s This feature requires Elementor Pro to use dynamic tags and field plugins like ACF, Meta Box, Toolset, etc.', 'cardcrafter-data-grids'),
                     '<strong>',
                     '</strong><br>'
                 ),

--- a/readme.txt
+++ b/readme.txt
@@ -2,9 +2,9 @@
 Contributors: fahdi
 Tags: json, cards, grid, data, layout
 Requires at least: 6.0
-Tested up to: 6.9
+Tested up to: 7.0
 Requires PHP: 7.4
-Stable tag: 1.14.1
+Stable tag: 1.14.2
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -198,6 +198,10 @@ CardCrafter works with any publicly accessible JSON endpoint. The API must allow
 10. **Mobile Responsive Design** - Cards automatically adapt to smaller screens with optimized spacing, typography, and touch-friendly interactions.
 
 == Changelog ==
+
+= 1.14.2 =
+* COMPATIBILITY: Tested with WordPress 7.0.
+* MAINTENANCE: Bumped supported WordPress version.
 
 = 1.14.1 =
 * HOTFIX: Resolved critical JavaScript error "Unexpected token '<'" preventing card loading


### PR DESCRIPTION
## Summary

Compat-only release: WordPress 7.0 support, plus one i18n fix surfaced by the audit.

### Changes
- `readme.txt`: `Tested up to: 6.9 → 7.0`, `Stable tag: 1.14.1 → 1.14.2`.
- `cardcrafter.php`: plugin header `Version: 1.14.1 → 1.14.2`, `CARDCRAFTER_VERSION` constant bump.
- Added 1.14.2 changelog entry.
- **Fix (elementor/class-cardcrafter-elementor-widget.php:346)**: i18n issue surfaced by `WordPress.WP.I18n` sniff:
  - Added `/* translators: */` comment for placeholders.
  - Changed unordered `%s, %s` to ordered `%1$s, %2$s`.

No other functional code changes.

### Verification (run locally against this branch)
- `php -l` — all PHP files parse clean under PHP 8.5.6.
- **PHPCompatibilityWP** standard (testVersion `7.4-`): 0 errors, 0 warnings (14 files).
- **WordPress WP.Deprecated*** sniffs: 0 errors, 0 warnings.
- **WordPress.WP.I18n** sniff (text domain `cardcrafter-data-grids`): 0 errors, 0 warnings (after the Elementor widget fix above).

### Note
`CHANGELOG.md` is currently out of sync with `readme.txt` (it stops at `1.13.1`; `readme.txt` has entries through `1.14.1`). Not addressed here since it's a pre-existing documentation drift unrelated to WP 7.0 compat, but worth a follow-up.

### Release plan
After merge: sync trunk to `plugins.svn.wordpress.org/cardcrafter-data-grids/trunk`, copy to `tags/1.14.2/`, `svn ci`.